### PR TITLE
fix: introduce azure_synapse_process TYPE to support columnMapping

### DIFF
--- a/assets/lineage-setup/synapse-purview-types/purview_synapse_notebook_process_basic_relationship.json
+++ b/assets/lineage-setup/synapse-purview-types/purview_synapse_notebook_process_basic_relationship.json
@@ -22,8 +22,8 @@
             "isLegacyAttribute": false
         },
         "endDef2": {
-            "type": "Process",
-            "name": "notebook",
+            "type": "azure_synapse_process",
+            "name": "synapse_notebook",
             "isContainer": false,
             "cardinality": "SINGLE",
             "isLegacyAttribute": false

--- a/assets/lineage-setup/synapse-purview-types/purview_synapse_notebook_typedef.json
+++ b/assets/lineage-setup/synapse-purview-types/purview_synapse_notebook_typedef.json
@@ -60,95 +60,33 @@
         ],
         "superTypes": [
             "Process"
-        ],
-        "subTypes": [],
-        "relationshipAttributeDefs": [
+        ]
+    },
+    {
+        "category": "ENTITY",
+        "name": "azure_synapse_process",
+        "description": "azure_synapse_process",
+        "typeVersion": "1.0",
+        "serviceType": "Azure Synapse Analytics",
+        "options": {
+            "defaultRenderedLineage": "synapse_notebook"
+        },
+        "attributeDefs": [
             {
-                "name": "represents",
-                "typeName": "Purview_DataDomain",
+                "name": "columnMapping",
+                "typeName": "string",
                 "isOptional": true,
                 "cardinality": "SINGLE",
-                "valuesMinCount": -1,
-                "valuesMaxCount": -1,
-                "isUnique": false,
-                "isIndexable": false,
-                "includeInNotification": false,
-                "relationshipTypeName": "Purview_Assets_DataDomain_Represents",
-                "isLegacyAttribute": false
-            },
-            {
-                "name": "outputs",
-                "typeName": "array<DataSet>",
-                "isOptional": true,
-                "cardinality": "SET",
                 "valuesMinCount": 0,
-                "valuesMaxCount": 2147483647,
+                "valuesMaxCount": 1,
                 "isUnique": false,
                 "isIndexable": false,
-                "includeInNotification": false,
-                "relationshipTypeName": "process_dataset_outputs",
-                "isLegacyAttribute": true
-            },
-            {
-                "name": "azure_synapse_workspace",
-                "typeName": "azure_synapse_workspace",
-                "isOptional": false,
-                "cardinality": "SINGLE",
-                "valuesMinCount": -1,
-                "valuesMaxCount": -1,
-                "isUnique": false,
-                "isIndexable": false,
-                "includeInNotification": false,
-                "relationshipTypeName": "azure_synapse_workspace_notebook",
-                "isLegacyAttribute": false
-            },
-            {
-                "name": "processes",
-                "typeName": "array<azure_synapse_process>",
-                "isOptional": true,
-                "cardinality": "SET",
-                "valuesMinCount": -1,
-                "valuesMaxCount": -1,
-                "isUnique": false,
-                "isIndexable": false,
-                "includeInNotification": false,
-                "constraints": [
-                    {
-                        "type": "ownedRef"
-                    }
-                ],
-                "relationshipTypeName": "azure_synapse_notebook_process",
-                "isLegacyAttribute": false
-            },
-            {
-                "name": "inputs",
-                "typeName": "array<DataSet>",
-                "isOptional": true,
-                "cardinality": "SET",
-                "valuesMinCount": 0,
-                "valuesMaxCount": 2147483647,
-                "isUnique": false,
-                "isIndexable": false,
-                "includeInNotification": false,
-                "relationshipTypeName": "dataset_process_inputs",
-                "isLegacyAttribute": true
-            },
-            {
-                "name": "meanings",
-                "typeName": "array<AtlasGlossaryTerm>",
-                "isOptional": true,
-                "cardinality": "SET",
-                "valuesMinCount": -1,
-                "valuesMaxCount": -1,
-                "isUnique": false,
-                "isIndexable": false,
-                "includeInNotification": false,
-                "relationshipTypeName": "AtlasGlossarySemanticAssignment",
-                "isLegacyAttribute": false
+                "includeInNotification": false
             }
-        
         ],
-        "businessAttributeDefs": {}
+        "superTypes": [
+            "Process"
+        ]
     }
 ]
 }

--- a/function-app/adb-to-purview/src/Function.Domain/Helpers/parser/ColParser.cs
+++ b/function-app/adb-to-purview/src/Function.Domain/Helpers/parser/ColParser.cs
@@ -46,7 +46,7 @@ namespace Function.Domain.Helpers
                 {
                   var dataSet = new DatasetMappingClass();
                     //dataSet.sink = $"{colId.NameSpace}, {colId.Name}";
-                    dataSet.sink = _qnParser.GetIdentifiers(colId.NameSpace, colId.Name).QualifiedName;
+                    dataSet.sink = _qnParser.GetIdentifiers(colId.NameSpace, colId.Name).QualifiedName.ToLower();
                     var columnLevels = new List<ColumnMappingClass>();
                     foreach (ColumnLineageIdentifierClass colInfo2 in colInfo.Value.inputFields)
                     {
@@ -59,7 +59,7 @@ namespace Function.Domain.Helpers
                                 colInfo2.name = x.Name;
                             }
                         }
-                        dataSet.source = _qnParser.GetIdentifiers(colInfo2.nameSpace, colInfo2.name).QualifiedName;
+                        dataSet.source = _qnParser.GetIdentifiers(colInfo2.nameSpace, colInfo2.name).QualifiedName.ToLower();
                         //dataSet.source = "*";
                         columnLevel.source = colInfo2.field;
                         columnLevel.sink = colInfo.Key;

--- a/function-app/adb-to-purview/src/Function.Domain/Models/Parser/Purview/DatabricksProcess.cs
+++ b/function-app/adb-to-purview/src/Function.Domain/Models/Parser/Purview/DatabricksProcess.cs
@@ -18,7 +18,7 @@ namespace Function.Domain.Models.Purview
       public class SynapseProcess
     {
         [JsonProperty("typeName")]
-        public string TypeName = "Process";
+        public string TypeName = "azure_synapse_process";
         [JsonProperty("attributes")]
         public SynapseProcessAttributes Attributes = new SynapseProcessAttributes();
         [JsonProperty("relationshipAttributes")]

--- a/function-app/adb-to-purview/src/Function.Domain/Models/Parser/Purview/DatabricksProcessRelationshipAttributes.cs
+++ b/function-app/adb-to-purview/src/Function.Domain/Models/Parser/Purview/DatabricksProcessRelationshipAttributes.cs
@@ -9,7 +9,7 @@ namespace Function.Domain.Models.Purview
 
      public class SynapseProcessRelationshipAttributes
     {
-        [JsonProperty("notebook")]
+        [JsonProperty("synapse_notebook")]
         public RelationshipAttribute Notebook = new RelationshipAttribute();
     }
 }


### PR DESCRIPTION
Hi @anildwarepo,

Recently I was looking for Synapse-Purview integration solution and a colleague recommended your Synapse-extended version based on the ADB-lineage-solution-accelerator; I tested a bit and it works quite well, thanks a lot!

### Major changes of this PR
During the testing, I found some small issues/enhancements, thanks for your help to take a review! 
- About the custom relationship between _azure_synapse_notebook_ and _Process_, in order to support column level lineage (columnMapping), I introduce a new custom entity type **_azure_synapse_process_**; and in order to skip a conflict error on the _endDef2.name_ key, I have to update its value from _notebook_ to **_synapse_notebook_**, the _notebook_ value has been used in a Databricks related entity type.

- For the new introduced type **_azure_synapse_process_** added to [purview_synapse_notebook_typedef.json](https://github.com/anildwarepo/Purview-ADB-Lineage-Solution-Accelerator/compare/release/2.1...thurstonchen:Purview-ADB-Lineage-Solution-Accelerator:release/2.1#diff-a9d88b7c2c427d93ddb5b9d7b7b356b0f5403e026da41ff3ee0aa8980a9b5c92) file, just added columnMapping attribute in order to support the column level lineage.
  Also removed the _relationshipAttributeDefs_ part, we notice the relationship attribute definitions only take effect after created the the relationship type, it's not necessary in entity type definition.

- Added qualified name to-lower logic to **ColParser.cs**, which is to fix a potential column-level lineage issue, since we have qualified name to-lower logic when sending data assets (source and target) entities to Purview ([SendToPurview](https://github.com/thurstonchen/Purview-ADB-Lineage-Solution-Accelerator/blob/release/2.1/function-app/adb-to-purview/src/Function.Domain/Services/PurviewIngestion.cs#L159)).

- About the **openlineage-spark** jar version, I've tested 0.18.0, the latest version mentioned in the ADB-version repo, the columMapping feature is not supported in 0.13.0 version.
  BTW, also tested version 0.28.0, which supports files level data assets, so that we see both InputA and InputB csv file assets in the below screenshot, but since version 0.22.0, the Spark configurations has introduce [incompatible updates](https://github.com/OpenLineage/OpenLineage/tree/0.21.1/integration/spark#http), we need to update the Spark cluster configs a bit.

### Test results
With all above changes, I tested the _abfss-in-abfss-out-olsample.scala_ sample and got below expected test results.
![image](https://github.com/anildwarepo/Purview-ADB-Lineage-Solution-Accelerator/assets/17846095/ab502ede-b6da-425f-b7e1-984266931639)


If you agree on the above changes, we could also update the README file a bit to introduce relevant changes as well, like update the openlineage-spark jar version, Spark cluster configs or relevant screenshots, thanks in advance! :- )


